### PR TITLE
External plugin support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name             = 'wrapyfi',
-    version          = '0.4.2',
+    version          = '0.4.3',
     description      = 'Wrapyfi is a wrapper for simplifying Middleware communication',
     url              = 'https://github.com/fabawi/wrapyfi/',
     author           = 'Fares Abawi',

--- a/wrapyfi/__init__.py
+++ b/wrapyfi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from wrapyfi.utils import PluginRegistrar
 

--- a/wrapyfi/connect/wrapper.py
+++ b/wrapyfi/connect/wrapper.py
@@ -1,3 +1,4 @@
+import os
 import copy
 from functools import wraps
 
@@ -6,7 +7,7 @@ import wrapyfi.connect.listeners as lsn
 from wrapyfi.utils import get_default_args, match_args
 from wrapyfi.config.manager import ConfigManager
 
-DEFAULT_COMMUNICATOR = "zeromq"
+DEFAULT_COMMUNICATOR = os.environ.get("WRAPYFI_DEFAULT_COMMUNICATOR", "zeromq")
 
 
 class MiddlewareCommunicator(object):

--- a/wrapyfi/connect/wrapper.py
+++ b/wrapyfi/connect/wrapper.py
@@ -7,7 +7,9 @@ import wrapyfi.connect.listeners as lsn
 from wrapyfi.utils import get_default_args, match_args
 from wrapyfi.config.manager import ConfigManager
 
-DEFAULT_COMMUNICATOR = os.environ.get("WRAPYFI_DEFAULT_COMMUNICATOR", "zeromq")
+
+WRAPYFI_DEFAULT_COMMUNICATOR = "WRAPYFI_DEFAULT_COMMUNICATOR"
+DEFAULT_COMMUNICATOR = os.environ.get(WRAPYFI_DEFAULT_COMMUNICATOR, "zeromq")
 
 
 class MiddlewareCommunicator(object):


### PR DESCRIPTION
1. Added support for external plugin extensions by adding path to "WRAPYFI_PLUGIN_PATHS" and having the plugin module with the "plugin" directory. "WRAPYFI_PLUGIN_PATHS" and the "plugin" subdirectory should contain "__init__.py". Extension follow the same format and structure as the "wrapyfi.plugin" package directory
2. Added support for changing the default communicator (middleware) using the environment variable "WRAPYFI_DEFAULT_COMMUNICATOR" set as one of the supported middleware -> "zeromq", "yarp", "ros2", "ros" e.g., 
``export WRAPYFI_DEFAULT_COMMUNICATOR=zeromq``