### PR TITLE
Renamed ROS2 to ROS 2 in compliance with the ROS 2 specifications https://www.ros.org/imgs/ROSBrandGuide.pdf

### DIFF
--- a/.github/workflows/manual_update_version.yml
+++ b/.github/workflows/manual_update_version.yml
@@ -17,7 +17,7 @@ jobs:
         pdm add setuptools
         pdm import setup.py
 
-    - name: Update ROS & ROS2 Interface Versions
+    - name: Update ROS & ROS 2 Interface Versions
       run: |
         VERSION=$(grep -oP '(?<=version = ")[^"]+' pyproject.toml)
         if [[ -z "$VERSION" ]]; then

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Note that the iCub package is not needed for Wrapyfi to work and does not have t
 * For installing ROS, follow the [ROS installation guide](http://wiki.ros.org/noetic/Installation/Ubuntu). 
 We recommend installing ROS on Conda using the [RoboStack](https://github.com/RoboStack/ros-noetic) environment.
 
-* For installing ROS2, follow the [ROS2 installation guide](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html). 
-We recommend installing ROS2 on Conda using the [RoboStack](https://github.com/RoboStack/ros-humble) environment.
+* For installing ROS2, follow the [ROS 2 installation guide](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html). 
+We recommend installing ROS 2 on Conda using the [RoboStack](https://github.com/RoboStack/ros-humble) environment.
 
 * ZeroMQ can be installed using pip: `pip install pyzmq`. 
 The xpub-xsub pattern followed in our ZeroMQ implementation requires a proxy broker. A broker is spawned by default as a daemon process.
@@ -61,7 +61,7 @@ A standalone broker can be found [here](https://github.com/fabawi/wrapyfi/tree/m
 
 * YARP >= v3.3.2 
 * ROS Noetic Ninjemys
-* ROS2 Humble Hawksbill **|** Galactic Geochelone **|** Foxy Fitzroy 
+* ROS 2 Humble Hawksbill **|** Galactic Geochelone **|** Foxy Fitzroy 
 * PyZMQ 16.0, 17.1 and 19.0
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -208,8 +208,8 @@ All messages are transmitted using the rospy python bindings as topic messages
 *(ROS2)*: 
 
 ```{warning}
-ROS2 requires a custom message to handle audio. This message must be compiled first before using Wrapyfi with ROS2 Audio. 
-Refer to [these instructions for compiling Wrapyfi ROS2 services and messages](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
+ROS 2 requires a custom message to handle audio. This message must be compiled first before using Wrapyfi with ROS 2 Audio. 
+Refer to [these instructions for compiling Wrapyfi ROS 2 services and messages](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
 ```
 
 All messages are transmitted using the rclpy python bindings as topic messages
@@ -218,7 +218,7 @@ All messages are transmitted using the rclpy python bindings as topic messages
 * **AudioChunk**: Transmits and receives a `numpy` audio chunk using `wrapyfi_ros2_interfaces.msg.ROS2AudioMessage`
 * **NativeObject**: Transmits and receives a `json` string supporting all native python objects, `numpy` arrays, and [other formats](#data-structure-types) using `std_msgs.msg.String`
 * **Properties**: Transmits properties [*planned for Wrapyfi v0.5*]
-* **ROS2Message**: Transmits and receives a single [ROS2 message](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html) per return decorator
+* **ROS2Message**: Transmits and receives a single [ROS 2 message](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html) per return decorator
 
 *(ZeroMQ)*:
 
@@ -268,8 +268,8 @@ The requester formats its arguments as *(\[args\], {kwargs})*
 *(ROS2)*:
 
 ```{warning}
-ROS2 requires custom services to handle arbitrary messages. These services must be compiled first before using Wrapyfi in this mode. 
-Refer to [these instructions for compiling Wrapyfi ROS2 services](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
+ROS 2 requires custom services to handle arbitrary messages. These services must be compiled first before using Wrapyfi in this mode. 
+Refer to [these instructions for compiling Wrapyfi ROS 2 services](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
 ```
 
 All messages are transmitted using the rclpy python bindings as services.
@@ -492,7 +492,7 @@ This can be achieved by setting:
 * `WRAPYFI_ZEROMQ_PARAM_PUB_PORT`: The parameter server pub-socket port. Defaults to 5655 (**currently not supported**)
 * `WRAPYFI_ZEROMQ_PARAM_SUB_PORT`: The parameter server sub-socket port. Defaults to 5656 (**currently not supported**)
 
-ROS and ROS2 queue sizes can be set by:
+ROS and ROS 2 queue sizes can be set by:
 
 * `WRAPYFI_ROS_QUEUE_SIZE`: Size of the queue buffer. Defaults to 5
 * `WRAPYFI_ROS2_QUEUE_SIZE`: Size of the queue buffer. Defaults to 5

--- a/docs/usage/User Guide/Communication Patterns.md
+++ b/docs/usage/User Guide/Communication Patterns.md
@@ -43,8 +43,8 @@ All messages are transmitted using the rospy python bindings as topic messages
 *(ROS2)*: 
 
 ```{warning}
-ROS2 requires a custom message to handle audio. This message must be compiled first before using Wrapyfi with ROS2 Audio. 
-Refer to [these instructions for compiling Wrapyfi ROS2 services and messages](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
+ROS 2 requires a custom message to handle audio. This message must be compiled first before using Wrapyfi with ROS 2 Audio. 
+Refer to [these instructions for compiling Wrapyfi ROS 2 services and messages](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
 ```
 
 All messages are transmitted using the rclpy python bindings as topic messages
@@ -53,7 +53,7 @@ All messages are transmitted using the rclpy python bindings as topic messages
 * **AudioChunk**: Transmits and receives a `numpy` audio chunk using `wrapyfi_ros2_interfaces.msg.ROS2AudioMessage`
 * **NativeObject**: Transmits and receives a `json` string supporting all native python objects, `numpy` arrays, and [other formats](<Plugins.md#data-structure-types>) using `std_msgs.msg.String`
 * **Properties**: Transmits properties [*planned for Wrapyfi v0.5*]
-* **ROS2Message**: Transmits and receives a single [ROS2 message](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html) per return decorator
+* **ROS2Message**: Transmits and receives a single [ROS 2 message](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html) per return decorator
 
 *(ZeroMQ)*:
 
@@ -103,8 +103,8 @@ The requester formats its arguments as *(\[args\], {kwargs})*
 *(ROS2)*:
 
 ```{warning}
-ROS2 requires custom services to handle arbitrary messages. These services must be compiled first before using Wrapyfi in this mode. 
-Refer to [these instructions for compiling Wrapyfi ROS2 services](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
+ROS 2 requires custom services to handle arbitrary messages. These services must be compiled first before using Wrapyfi in this mode. 
+Refer to [these instructions for compiling Wrapyfi ROS 2 services](https://github.com/fabawi/wrapyfi/tree/master/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md).
 ```
 
 All messages are transmitted using the rclpy python bindings as services.

--- a/docs/usage/User Guide/Environment Variables.md
+++ b/docs/usage/User Guide/Environment Variables.md
@@ -21,7 +21,7 @@ This can be achieved by setting:
 * `WRAPYFI_ZEROMQ_PARAM_PUB_PORT`: The parameter server pub-socket port. Defaults to 5655 (**currently not supported**)
 * `WRAPYFI_ZEROMQ_PARAM_SUB_PORT`: The parameter server sub-socket port. Defaults to 5656 (**currently not supported**)
 
-ROS and ROS2 queue sizes can be set by:
+ROS and ROS 2 queue sizes can be set by:
 
 * `WRAPYFI_ROS_QUEUE_SIZE`: Size of the queue buffer. Defaults to 5
 * `WRAPYFI_ROS2_QUEUE_SIZE`: Size of the queue buffer. Defaults to 5

--- a/examples/custom_msgs/ros2_message_example.py
+++ b/examples/custom_msgs/ros2_message_example.py
@@ -1,27 +1,27 @@
 """
-A message publisher and listener for ROS2 messages using Wrapyfi.
+A message publisher and listener for ROS 2 messages using Wrapyfi.
 
-This script demonstrates the capability to transmit ROS2 messages, specifically
+This script demonstrates the capability to transmit ROS 2 messages, specifically
 geometry_msgs/Pose and std_msgs/String, using the MiddlewareCommunicator within
 the Wrapyfi library. The communication follows the PUB/SUB pattern allowing
 message publishing and listening functionalities between processes or machines.
 
 Demonstrations:
-    - Using the ROS2 message
-    - Transmitting std_msgs/String and geometry_msgs/Pose ROS2 messages
+    - Using the ROS 2 message
+    - Transmitting std_msgs/String and geometry_msgs/Pose ROS 2 messages
     - Applying the PUB/SUB pattern with channeling and mirroring
 
 Requirements:
     - Wrapyfi: Middleware communication wrapper (refer to the Wrapyfi documentation for installation instructions)
-    - ROS2, rclpy: Used for handling and creating ROS2 messages (refer to the Wrapyfi documentation for installation instructions)
+    - ROS2, rclpy: Used for handling and creating ROS 2 messages (refer to the Wrapyfi documentation for installation instructions)
 
-    Ensure ROS2 is installed and the required message types are available.
+    Ensure ROS 2 is installed and the required message types are available.
 
 Run:
     # On machine 1 (or process 1): Publisher waits for keyboard input and transmits message
         ``python3 ros2_message_example.py --mode publish``
 
-    # On machine 2 (or process 2): Listener waits for message and prints the received ROS2 messages
+    # On machine 2 (or process 2): Listener waits for message and prints the received ROS 2 messages
         ``python3 ros2_message_example.py --mode listen``
 """
 
@@ -43,7 +43,7 @@ class Notifier(MiddlewareCommunicator):
         should_wait=True
     )
     def send_message(self):
-        """Exchange ROS2 messages over ROS2."""
+        """Exchange ROS 2 messages over ROS2."""
         msg = input("Type your message: ")
         quat = Quaternion()
         quat.x = 0.1

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -2,7 +2,7 @@
 This example shows how to use the MiddlewareCommunicator to send and receive messages. It can be used to test the
 functionality of the middleware using the PUB/SUB pattern and the REQ/REP pattern. The example can be run on a single
 machine or on multiple machines. In this example (as with all other examples), the communication middleware is selected
-using the ``--mware`` argument. The default is ZeroMQ, but YARP, ROS, and ROS2 are also supported.
+using the ``--mware`` argument. The default is ZeroMQ, but YARP, ROS, and ROS 2 are also supported.
 
 Requirements:
     - Wrapyfi: Middleware communication wrapper (refer to the Wrapyfi documentation for installation instructions)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def check_cv2(default_python="opencv-python"):
 
 setuptools.setup(
     name             = 'wrapyfi',
-    version          = '0.4.26',
+    version          = '0.4.27',
     description      = 'Wrapyfi is a wrapper for simplifying Middleware communication',
     url              = 'https://github.com/fabawi/wrapyfi/blob/master/',
     project_urls={

--- a/upgrade_project.sh
+++ b/upgrade_project.sh
@@ -22,7 +22,7 @@ update_version_in_package_xml() {
     echo "Version updated to $VERSION in $PACKAGE_XML_PATH"
 }
 
-# UPDATE ROS & ROS2 INTERFACE VERSIONS
+# UPDATE ROS & ROS 2 INTERFACE VERSIONS
 #######################################################################################################################
 
 # get the version from pyproject.toml

--- a/wrapyfi/clients/ros2.py
+++ b/wrapyfi/clients/ros2.py
@@ -26,13 +26,13 @@ class ROS2Client(Client, Node):
 
         :param name: str: Name of the client
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
-        :param ros2_kwargs: dict: Additional kwargs for the ROS2 middleware
+        :param ros2_kwargs: dict: Additional kwargs for the ROS 2 middleware
         :param kwargs: dict: Additional kwargs for the client
         """
         carrier = "tcp"
         if "carrier" in kwargs and kwargs["carrier"] not in ["", None]:
             logging.warning(
-                "[ROS2] ROS2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
+                "[ROS2] ROS 2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
         if "carrier" in kwargs:
             del kwargs["carrier"]
         ROS2Middleware.activate(**ros2_kwargs or {})
@@ -57,7 +57,7 @@ class ROS2NativeObjectClient(ROS2Client):
                  serializer_kwargs: Optional[dict] = None,
                  deserializer_kwargs: Optional[dict] = None, **kwargs):
         """
-        The NativeObject listener using the ROS2 String message assuming the data is serialized as a JSON string.
+        The NativeObject listener using the ROS 2 String message assuming the data is serialized as a JSON string.
         Deserializes the data (including plugins) using the decoder and parses it to a Python object.
 
         :param name: str: Name of the client
@@ -77,14 +77,14 @@ class ROS2NativeObjectClient(ROS2Client):
 
     def establish(self):
         """
-        Establish the client's connection to the ROS2 service.
+        Establish the client's connection to the ROS 2 service.
         """
         try:
             from wrapyfi_ros2_interfaces.srv import ROS2NativeObjectService
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2NativeObjectService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -97,11 +97,11 @@ class ROS2NativeObjectClient(ROS2Client):
 
     def request(self, *args, **kwargs):
         """
-        Send a request to the ROS2 service.
+        Send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
-        :return: Any: The response from the ROS2 service
+        :return: Any: The response from the ROS 2 service
         """
         if not self.established:
             self.establish()
@@ -113,7 +113,7 @@ class ROS2NativeObjectClient(ROS2Client):
 
     def _request(self, *args, **kwargs):
         """
-        Internal method to send a request to the ROS2 service.
+        Internal method to send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
@@ -137,9 +137,9 @@ class ROS2NativeObjectClient(ROS2Client):
 
     def _await_reply(self) -> Any:
         """
-        Wait for and return the reply from the ROS2 service.
+        Wait for and return the reply from the ROS 2 service.
 
-        :return: Any: The response from the ROS2 service
+        :return: Any: The response from the ROS 2 service
         """
         try:
             reply = self._queue.get(block=True)
@@ -155,7 +155,7 @@ class ROS2ImageClient(ROS2Client):
     def __init__(self, name: str, in_topic: str, width: int = -1, height: int = -1,
                  rgb: bool = True, fp: bool = False, jpg: bool = False, serializer_kwargs: Optional[dict] = None, **kwargs):
         """
-        The Image client using the ROS2 Image message parsed to a numpy array.
+        The Image client using the ROS 2 Image message parsed to a numpy array.
 
         :param name: str: Name of the client
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
@@ -193,14 +193,14 @@ class ROS2ImageClient(ROS2Client):
 
     def establish(self):
         """
-        Establish the client's connection to the ROS2 service.
+        Establish the client's connection to the ROS 2 service.
         """
         try:
             from wrapyfi_ros2_interfaces.srv import ROS2ImageService, ROS2CompressedImageService
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2ImageService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -217,11 +217,11 @@ class ROS2ImageClient(ROS2Client):
 
     def request(self, *args, **kwargs):
         """
-        Send a request to the ROS2 service.
+        Send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
-        :return: Any: The response from the ROS2 service
+        :return: Any: The response from the ROS 2 service
         """
         if not self.established:
             self.establish()
@@ -233,7 +233,7 @@ class ROS2ImageClient(ROS2Client):
 
     def _request(self, *args, **kwargs):
         """
-        Internal method to send a request to the ROS2 service.
+        Internal method to send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
@@ -261,9 +261,9 @@ class ROS2ImageClient(ROS2Client):
 
     def _await_reply(self):
         """
-        Wait for and return the reply from the ROS2 service.
+        Wait for and return the reply from the ROS 2 service.
 
-        :return: np.array: The received image from the ROS2 service
+        :return: np.array: The received image from the ROS 2 service
         """
         try:
             if self.jpg:
@@ -296,7 +296,7 @@ class ROS2AudioChunkClient(ROS2Client):
                  channels: int = 1, rate: int = 44100, chunk: int = -1,
                  serializer_kwargs: Optional[dict] = None, **kwargs):
         """
-        The AudioChunk client using the ROS2 Audio message parsed to a numpy array.
+        The AudioChunk client using the ROS 2 Audio message parsed to a numpy array.
 
         :param name: str: Name of the client
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
@@ -322,14 +322,14 @@ class ROS2AudioChunkClient(ROS2Client):
 
     def establish(self):
         """
-        Establish the client's connection to the ROS2 service.
+        Establish the client's connection to the ROS 2 service.
         """
         try:
             from wrapyfi_ros2_interfaces.srv import ROS2AudioService
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2AudioService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -342,11 +342,11 @@ class ROS2AudioChunkClient(ROS2Client):
 
     def request(self, *args, **kwargs):
         """
-        Send a request to the ROS2 service.
+        Send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
-        :return: Any: The response from the ROS2 service
+        :return: Any: The response from the ROS 2 service
         """
         if not self.established:
             self.establish()
@@ -358,7 +358,7 @@ class ROS2AudioChunkClient(ROS2Client):
 
     def _request(self, *args, **kwargs):
         """
-        Internal method to send a request to the ROS2 service.
+        Internal method to send a request to the ROS 2 service.
 
         :param args: tuple: Positional arguments to send in the request
         :param kwargs: dict: Keyword arguments to send in the request
@@ -382,7 +382,7 @@ class ROS2AudioChunkClient(ROS2Client):
 
     def _await_reply(self):
         """
-        Wait for and return the reply from the ROS2 service.
+        Wait for and return the reply from the ROS 2 service.
 
         :return: Tuple[np.ndarray, int]: The received message as a numpy array formatted as (np.ndarray[audio_chunk, channels], int[samplerate])
         """

--- a/wrapyfi/listeners/ros2.py
+++ b/wrapyfi/listeners/ros2.py
@@ -36,12 +36,12 @@ class ROS2Listener(Listener, Node):
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
         :param should_wait: bool: Whether the subscriber should wait for the publisher to transmit a message. Default is True
         :param queue_size: int: Size of the queue for the subscriber. Default is 5
-        :param ros2_kwargs: dict: Additional kwargs for the ROS2 middleware
+        :param ros2_kwargs: dict: Additional kwargs for the ROS 2 middleware
         :param kwargs: dict: Additional kwargs for the subscriber
         """
         carrier = "tcp"
         if "carrier" in kwargs and kwargs["carrier"] not in ["", None]:
-            logging.warning("[ROS2] ROS2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
+            logging.warning("[ROS2] ROS 2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
         if "carrier" in kwargs:
             del kwargs["carrier"]
 
@@ -69,7 +69,7 @@ class ROS2NativeObjectListener(ROS2Listener):
     def __init__(self, name: str, in_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE,
                  deserializer_kwargs: Optional[dict] = None, **kwargs):
         """
-        The NativeObject listener using the ROS2 String message assuming the data is serialized as a JSON string.
+        The NativeObject listener using the ROS 2 String message assuming the data is serialized as a JSON string.
         Deserializes the data (including plugins) using the decoder and parses it to a native object.
 
         :param name: str: Name of the subscriber
@@ -128,7 +128,7 @@ class ROS2ImageListener(ROS2Listener):
     def __init__(self, name: str, in_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE,
                  width: int = -1, height: int = -1, rgb: bool = True, fp: bool = False, jpg: bool = False, **kwargs):
         """
-        The Image listener using the ROS2 Image message parsed to a numpy array.
+        The Image listener using the ROS 2 Image message parsed to a numpy array.
 
         :param name: str: Name of the subscriber
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
@@ -226,7 +226,7 @@ class ROS2AudioChunkListener(ROS2Listener):
     def __init__(self, name: str, in_topic: str, should_wait: bool = True,
                  queue_size: int = QUEUE_SIZE, channels: int = 1, rate: int = 44100, chunk: int = -1, **kwargs):
         """
-        The AudioChunk listener using the ROS2 Audio message parsed to a numpy array.
+        The AudioChunk listener using the ROS 2 Audio message parsed to a numpy array.
 
         :param name: str: Name of the subscriber
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
@@ -254,7 +254,7 @@ class ROS2AudioChunkListener(ROS2Listener):
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2AudioMessage. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -309,7 +309,7 @@ class ROS2MessageListener(ROS2Listener):
 
     def __init__(self, name: str, in_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE, **kwargs):
         """
-        The ROS2MessageListener using the ROS2 message type inferred from the message type. Supports standard ROS2 msgs.
+        The ROS2MessageListener using the ROS 2 message type inferred from the message type. Supports standard ROS 2 msgs.
 
         :param name: str: Name of the subscriber
         :param in_topic: str: Name of the input topic preceded by '/' (e.g. '/topic')
@@ -356,7 +356,7 @@ class ROS2MessageListener(ROS2Listener):
         """
         Listen for a message.
 
-        :return: ROS2Message: The received message as a ROS2 message object
+        :return: ROS2Message: The received message as a ROS 2 message object
         """
         if not self.established:
             self.establish()

--- a/wrapyfi/middlewares/ros2.py
+++ b/wrapyfi/middlewares/ros2.py
@@ -9,7 +9,7 @@ from wrapyfi.connect.wrapper import MiddlewareCommunicator
 
 class ROS2Middleware(metaclass=SingletonOptimized):
     """
-    ROS2 middleware wrapper. This class is a singleton, so it can be instantiated only once. The ``activate`` method
+    ROS 2 middleware wrapper. This class is a singleton, so it can be instantiated only once. The ``activate`` method
     should be called to initialize the middleware. The ``deinit`` method should be called to deinitialize the middleware
     and destroy all connections. The ``activate`` and ``deinit`` methods are automatically called when the class is
     instantiated and when the program exits, respectively.
@@ -18,20 +18,20 @@ class ROS2Middleware(metaclass=SingletonOptimized):
     @staticmethod
     def activate(**kwargs):
         """
-        Activate the ROS2 middleware. This method should be called to initialize the middleware.
+        Activate the ROS 2 middleware. This method should be called to initialize the middleware.
 
-        :param kwargs: dict: Keyword arguments to be passed to the ROS2 initialization function
+        :param kwargs: dict: Keyword arguments to be passed to the ROS 2 initialization function
         """
         ROS2Middleware(**kwargs)
 
     def __init__(self, *args, **kwargs):
         """
-        Initialize the ROS2 middleware. This method is automatically called when the class is instantiated.
+        Initialize the ROS 2 middleware. This method is automatically called when the class is instantiated.
 
-        :param args: list: Positional arguments to be passed to the ROS2 initialization function
-        :param kwargs: dict: Keyword arguments to be passed to the ROS2 initialization function
+        :param args: list: Positional arguments to be passed to the ROS 2 initialization function
+        :param kwargs: dict: Keyword arguments to be passed to the ROS 2 initialization function
         """
-        logging.info("Initialising ROS2 middleware")
+        logging.info("Initialising ROS 2 middleware")
         rclpy.init(args=[*args], **kwargs)
         atexit.register(MiddlewareCommunicator.close_all_instances)
         atexit.register(self.deinit)
@@ -39,8 +39,8 @@ class ROS2Middleware(metaclass=SingletonOptimized):
     @staticmethod
     def deinit():
         """
-        Deinitialize the ROS2 middleware. This method is automatically called when the program exits.
+        Deinitialize the ROS 2 middleware. This method is automatically called when the program exits.
         """
-        logging.info("Deinitializing ROS2 middleware")
+        logging.info("Deinitializing ROS 2 middleware")
         rclpy.try_shutdown()
 

--- a/wrapyfi/publishers/ros2.py
+++ b/wrapyfi/publishers/ros2.py
@@ -33,12 +33,12 @@ class ROS2Publisher(Publisher, Node):
         :param out_topic: str: Name of the output topic preceded by '/' (e.g. '/topic')
         :param should_wait: bool: Whether to wait for at least one listener before unblocking the script. Default is True
         :param queue_size: int: Queue size for the publisher. Default is 5
-        :param ros2_kwargs: dict: Additional kwargs for the ROS2 middleware
+        :param ros2_kwargs: dict: Additional kwargs for the ROS 2 middleware
         :param kwargs: dict: Additional kwargs for the publisher
         """
         carrier = "tcp"
         if "carrier" in kwargs and kwargs["carrier"] not in ["", None]:
-            logging.warning("[ROS2] ROS2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
+            logging.warning("[ROS2] ROS 2 currently does not support explicit carrier setting for PUB/SUB pattern. Using TCP.")
         if "carrier" in kwargs:
             del kwargs["carrier"]
         ROS2Middleware.activate(**ros2_kwargs or {})
@@ -92,7 +92,7 @@ class ROS2NativeObjectPublisher(ROS2Publisher):
     def __init__(self, name, out_topic: str, should_wait: bool = True,
                  queue_size: int = QUEUE_SIZE, serializer_kwargs: Optional[dict] = None, **kwargs):
         """
-        The NativeObject publisher using the ROS2 String message assuming a combination of python native objects
+        The NativeObject publisher using the ROS 2 String message assuming a combination of python native objects
         and numpy arrays as input. Serializes the data (including plugins) using the encoder and sends it as a string.
 
         :param name: str: Name of the publisher
@@ -147,7 +147,7 @@ class ROS2ImagePublisher(ROS2Publisher):
     def __init__(self, name: str, out_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE,
                  width: int = -1, height: int = -1, rgb: bool = True, fp: bool = False, jpg: bool = False, **kwargs):
         """
-        The ImagePublisher using the ROS2 Image message assuming a numpy array as input.
+        The ImagePublisher using the ROS 2 Image message assuming a numpy array as input.
 
         :param name: str: Name of the publisher
         :param out_topic: str: Name of the output topic preceded by '/' (e.g. '/topic')
@@ -239,7 +239,7 @@ class ROS2AudioChunkPublisher(ROS2Publisher):
     def __init__(self, name: str, out_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE,
                  channels: int = 1, rate: int = 44100, chunk: int = -1, **kwargs):
         """
-        The AudioChunkPublisher using the ROS2 Audio message assuming a numpy array as input.
+        The AudioChunkPublisher using the ROS 2 Audio message assuming a numpy array as input.
 
         :param name: str: Name of the publisher
         :param out_topic: str: Name of the output topic preceded by '/' (e.g. '/topic')
@@ -271,7 +271,7 @@ class ROS2AudioChunkPublisher(ROS2Publisher):
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2AudioMessage. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -329,7 +329,7 @@ class ROS2MessagePublisher(ROS2Publisher):
 
     def __init__(self, name: str, out_topic: str, should_wait: bool = True, queue_size: int = QUEUE_SIZE, **kwargs):
         """
-        The ROS2MessagePublisher using the ROS2 message type determined dynamically.
+        The ROS2MessagePublisher using the ROS 2 message type determined dynamically.
 
         :param name: str: Name of the publisher
         :param out_topic: str: Name of the output topic preceded by '/' (e.g. '/topic')
@@ -347,7 +347,7 @@ class ROS2MessagePublisher(ROS2Publisher):
         """
         Get the type of a specific message.
 
-        :param msg: ROS2 message object
+        :param msg: ROS 2 message object
         :return: type: The type of the provided message
         """
         return type(msg)

--- a/wrapyfi/servers/ros2.py
+++ b/wrapyfi/servers/ros2.py
@@ -28,13 +28,13 @@ class ROS2Server(Server, Node):
 
         :param name: str: Name of the server
         :param out_topic: str: Name of the output topic preceded by '/' (e.g. '/topic')
-        :param ros2_kwargs: dict: Additional kwargs for the ROS2 middleware
+        :param ros2_kwargs: dict: Additional kwargs for the ROS 2 middleware
         :param kwargs: dict: Additional kwargs for the server
         """
         carrier = "tcp"
         if "carrier" in kwargs and kwargs["carrier"] not in ["", None]:
             logging.warning(
-                "[ROS2] ROS2 currently does not support explicit carrier setting for REQ/REP pattern. Using TCP.")
+                "[ROS2] ROS 2 currently does not support explicit carrier setting for REQ/REP pattern. Using TCP.")
         if "carrier" in kwargs:
             del kwargs["carrier"]
 
@@ -90,7 +90,7 @@ class ROS2NativeObjectServer(ROS2Server):
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2NativeObjectService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -129,7 +129,7 @@ class ROS2NativeObjectServer(ROS2Server):
     @staticmethod
     def _service_callback(request, _response):
         """
-        Callback for the ROS2 service.
+        Callback for the ROS 2 service.
 
         :param request: ROS2NativeObjectService.Request: The request message
         :param _response: ROS2NativeObjectService.Response: The response message
@@ -207,7 +207,7 @@ class ROS2ImageServer(ROS2Server):
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2NativeObjectService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -249,7 +249,7 @@ class ROS2ImageServer(ROS2Server):
     @staticmethod
     def _service_callback(request, _response):
         """
-        Callback for the ROS2 service.
+        Callback for the ROS 2 service.
 
         :param request: ROS2NativeObjectService.Request: The request message
         :param _response: ROS2NativeObjectService.Response: The response message
@@ -326,7 +326,7 @@ class ROS2AudioChunkServer(ROS2Server):
         except ImportError:
             import wrapyfi
             logging.error("[ROS2] Could not import ROS2AudioService. "
-                          "Make sure the ROS2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
+                          "Make sure the ROS 2 services in wrapyfi_extensions/wrapyfi_ros2_interfaces are compiled. "
                           "Refer to the documentation for more information: \n" +
                           wrapyfi.__url__ + "wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md")
             sys.exit(1)
@@ -363,7 +363,7 @@ class ROS2AudioChunkServer(ROS2Server):
     @staticmethod
     def _service_callback(request, _response):
         """
-        Callback for the ROS2 service.
+        Callback for the ROS 2 service.
 
         :param request: ROS2NativeObjectService.Request: The request message
         :param _response: ROS2NativeObjectService.Response: The response message

--- a/wrapyfi/tests/test_middleware.py
+++ b/wrapyfi/tests/test_middleware.py
@@ -47,8 +47,8 @@ class ZeroMQTestMiddleware(unittest.TestCase):
 
 class ROS2TestMiddleware(ZeroMQTestMiddleware):
     """
-    Test the ROS2 wrapper. This test class inherits from the ZeroMQ test class, so all tests from the ZeroMQ test class
-    are also run for the ROS2 wrapper.
+    Test the ROS 2 wrapper. This test class inherits from the ZeroMQ test class, so all tests from the ZeroMQ test class
+    are also run for the ROS 2 wrapper.
     """
     MWARE = "ros2"
 

--- a/wrapyfi/tests/test_wrapper.py
+++ b/wrapyfi/tests/test_wrapper.py
@@ -137,8 +137,8 @@ class ZeroMQTestWrapper(unittest.TestCase):
 
 class ROS2TestWrapper(ZeroMQTestWrapper):
     """
-    Test the ROS2 wrapper. This test class inherits from the ZeroMQ test class, so all tests from the ZeroMQ test class
-    are also run for the ROS2 wrapper.
+    Test the ROS 2 wrapper. This test class inherits from the ZeroMQ test class, so all tests from the ZeroMQ test class
+    are also run for the ROS 2 wrapper.
     """
     MWARE = "ros2"
 

--- a/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md
+++ b/wrapyfi_extensions/wrapyfi_ros2_interfaces/README.md
@@ -1,21 +1,21 @@
-# Compiling ROS2 interfaces
+# Compiling ROS 2 interfaces
 
 **WARNING**: These instructions are located in 
 https://github.com/fabawi/wrapyfi/blob/master/wrapyfi_extensions/wrapyfi_ros2_interfaces
 
-To run the Wrapyfi ROS2 services and transmit audio messages, you need to compile the ROS2 interfaces. 
-ROS2 must already be installed on your system, with all its build dependencies. 
+To run the Wrapyfi ROS 2 services and transmit audio messages, you need to compile the ROS 2 interfaces. 
+ROS 2 must already be installed on your system, with all its build dependencies. 
 You can find the installation instructions [here](https://docs.ros.org/en/humble/Installation.html) 
 or install using [Robostack](https://robostack.github.io/GettingStarted.html).
 
 ## Prerequisites
 
-- ROS2 Galactic/Humble
+- ROS 2 Galactic/Humble
 - Python 3.6
 
 ## Compiling
 
-1. Copy the `wrapyfi_ros2_interfaces` folder to your ROS2 workspace (assumed to be `~/ros2_ws`).
+1. Copy the `wrapyfi_ros2_interfaces` folder to your ROS 2 workspace (assumed to be `~/ros2_ws`).
 
     ```bash
     # from the current directory 
@@ -24,7 +24,7 @@ or install using [Robostack](https://robostack.github.io/GettingStarted.html).
     
     ```
 
-2. Compile the ROS2 interfaces:
+2. Compile the ROS 2 interfaces:
     
     ```bash
     cd ~/ros2_ws
@@ -43,13 +43,13 @@ or install using [Robostack](https://robostack.github.io/GettingStarted.html).
     
     Replacing VERSION 3.5 with the correct version of cmake.
 
-3. Source the ROS2 workspace:
+3. Source the ROS 2 workspace:
 
     ```bash
     source ~/ros2_ws/install/setup.bash
     ```
 
-4. Verify that the ROS2 Native object service interface is compiled:
+4. Verify that the ROS 2 Native object service interface is compiled:
     
     ```bash
     ros2 interface show wrapyfi_ros2_interfaces/srv/ROS2NativeObjectService
@@ -63,7 +63,7 @@ or install using [Robostack](https://robostack.github.io/GettingStarted.html).
     string response
     ```
 
-5. Verify that the ROS2 Image service interface is compiled:
+5. Verify that the ROS 2 Image service interface is compiled:
         
     ```bash
     ros2 interface show wrapyfi_ros2_interfaces/srv/ROS2ImageService
@@ -98,7 +98,7 @@ or install using [Robostack](https://robostack.github.io/GettingStarted.html).
     
     ```
 
-6. Verify that the ROS2 Audio service interface is compiled:
+6. Verify that the ROS 2 Audio service interface is compiled:
         
     ```bash
     ros2 interface show wrapyfi_ros2_interfaces/srv/ROS2AudioService
@@ -127,5 +127,5 @@ or install using [Robostack](https://robostack.github.io/GettingStarted.html).
     
     ```
    
-     Run your Wrapyfi enabled script from the same terminal. Now you can use the REQ/REP pattern (server/client) in Wrapyfi, and transmit ROS2 audio messages.
+     Run your Wrapyfi enabled script from the same terminal. Now you can use the REQ/REP pattern (server/client) in Wrapyfi, and transmit ROS 2 audio messages.
      

--- a/wrapyfi_extensions/wrapyfi_ros2_interfaces/package.xml
+++ b/wrapyfi_extensions/wrapyfi_ros2_interfaces/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>wrapyfi_ros2_interfaces</name>
   <version>0.4.26</version>
-  <description>Wrapyfi ROS2 interfaces</description>
+  <description>Wrapyfi ROS 2 interfaces</description>
   <maintainer email="fares.abawi@outlook.com">Fares Abawi</maintainer>
   <license>MIT</license>
 


### PR DESCRIPTION
Following the naming specifications found in https://www.ros.org/imgs/ROSBrandGuide.pdf specifying that ROS should be followed by space when indicating the version