### PR TITLE
Renamed all occurrences of Pandas to pandas in compliance with the pandas specifications https://pandas.pydata.org/about/citing.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,14 +298,14 @@ Supported Objects by the `NativeObject` type include:
 * [x] [**JAX Tensor**](https://jax.readthedocs.io/en/latest/)
 * [x] [**MXNet Tensor**](https://mxnet.apache.org/versions/1.9.1/api/python.html)
 * [x] [**Paddlepaddle Tensor**](https://www.paddlepaddle.org.cn/documentation/docs/en/guides/index_en.html)
-* [x] [**Pandas DataFrame|Series**](https://pandas.pydata.org/docs/)
+* [x] [**pandas DataFrame|Series**](https://pandas.pydata.org/docs/)
 * [x] [**Pillow Image**](https://pillow.readthedocs.io/en/stable/reference/Image.html)
 * [x] [**PyArrow Array**](https://arrow.apache.org/docs/python/index.html)
 * [x] [**Xarray DataArray|Dataset**](http://xarray.pydata.org/en/stable/)
 * [x] [**Dask Array|DataFrame**](https://www.dask.org/get-started)
 * [x] [**Zarr Array|Group**](https://zarr.readthedocs.io/en/stable/)
 * [x] [**Pint Quantity**](https://pint.readthedocs.io/en/stable/)
-* [ ] [**Pandas 2.0 DataFrame|Series**](https://pandas.pydata.org/docs/)
+* [ ] [**pandas 2.0 DataFrame|Series**](https://pandas.pydata.org/docs/)
 * [ ] [**Gmpy 2 MPZ**](https://gmpy2.readthedocs.io/en/latest/) 
 
 ## Image

--- a/examples/encoders/numpy_pandas_example.py
+++ b/examples/encoders/numpy_pandas_example.py
@@ -1,13 +1,13 @@
 """
-A message publisher and listener for native Python objects, NumPy Arrays, and Pandas Series/Dataframes.
+A message publisher and listener for native Python objects, NumPy Arrays, and pandas Series/Dataframes.
 
-This script demonstrates the capability to transmit native Python objects, NumPy arrays, and Pandas series/dataframes using
+This script demonstrates the capability to transmit native Python objects, NumPy arrays, and pandas series/dataframes using
 the MiddlewareCommunicator within the Wrapyfi library. The communication follows the PUB/SUB pattern
 allowing message publishing and listening functionalities between processes or machines.
 
 Demonstrations:
     - Using the NativeObject message
-    - Transmitting a nested dummy Python object with native objects, NumPy arrays, and Pandas series/dataframes
+    - Transmitting a nested dummy Python object with native objects, NumPy arrays, and pandas series/dataframes
     - Applying the PUB/SUB pattern with mirroring
 
 Requirements:
@@ -44,7 +44,7 @@ class Notifier(MiddlewareCommunicator):
         carrier="tcp", should_wait=True
     )
     def exchange_object(self, mware=None):
-        """Exchange messages with NumPy arrays, Pandas series/dataframes, and other native Python objects."""
+        """Exchange messages with NumPy arrays, pandas series/dataframes, and other native Python objects."""
         msg = input("Type your message: ")
 
         ret = {
@@ -59,7 +59,7 @@ class Notifier(MiddlewareCommunicator):
 
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="A message publisher and listener for native Python objects, NumPy arrays, and Pandas series/dataframes.")
+    parser = argparse.ArgumentParser(description="A message publisher and listener for native Python objects, NumPy arrays, and pandas series/dataframes.")
     parser.add_argument(
         "--mode", type=str, default="publish",
         choices={"publish", "listen"},

--- a/wrapyfi/plugins/dask_data.py
+++ b/wrapyfi/plugins/dask_data.py
@@ -11,7 +11,7 @@ Requirements:
     - Wrapyfi: Middleware communication wrapper (refer to the Wrapyfi documentation for installation instructions)
     - Dask: A flexible library for parallel computing in Python (refer to https://docs.dask.org/en/latest/install.html for installation instructions)
     - Pandas: A data structures library for data analysis, time series, and statistics (refer to https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html for installation instructions)
-        Note: If Dask or Pandas is not available, HAVE_DASK will be set to False and
+        Note: If Dask or pandas is not available, HAVE_DASK will be set to False and
         the plugin will be registered with no types.
 
     You can install the necessary packages using pip:

--- a/wrapyfi/plugins/pandas_data.py
+++ b/wrapyfi/plugins/pandas_data.py
@@ -1,16 +1,16 @@
 """
-Encoder and Decoder for Pandas Series/Dataframes Data via Wrapyfi.
+Encoder and Decoder for pandas Series/Dataframes Data via Wrapyfi.
 
-This script provides mechanisms to encode and decode Pandas data using Wrapyfi.
+This script provides mechanisms to encode and decode pandas data using Wrapyfi.
 It utilizes base64 encoding to convert binary data into ASCII strings.
 
 The script contains a class, `PandasData`, registered as a plugin to manage the
-conversion of Pandas data (if available) between its original and encoded forms.
+conversion of pandas data (if available) between its original and encoded forms.
 
 Requirements:
     - Wrapyfi: Middleware communication wrapper (refer to the Wrapyfi documentation for installation instructions)
     - Pandas: A data structures library for data analysis, time series, and statistics (refer to https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html for installation instructions)
-        Note: If Pandas is not available, HAVE_PANDAS will be set to False and
+        Note: If pandas is not available, HAVE_PANDAS will be set to False and
         the plugin will be registered with no types.
 
     You can install the necessary packages using pip:
@@ -41,9 +41,9 @@ class PandasData(Plugin):
 
     def encode(self, obj, *args, **kwargs):
         """
-        Encode Pandas data into a base64 ASCII string.
+        Encode pandas data into a base64 ASCII string.
 
-        :param obj: Union[pandas.DataFrame, pandas.Series]: The Pandas data to encode
+        :param obj: Union[pandas.DataFrame, pandas.Series]: The pandas data to encode
         :param args: tuple: Additional arguments (not used)
         :param kwargs: dict: Additional keyword arguments (not used)
         :return: Tuple[bool, dict]: A tuple containing:
@@ -63,7 +63,7 @@ class PandasData(Plugin):
 
     def decode(self, obj_type, obj_full, *args, **kwargs):
         """
-        Decode a base64 ASCII string back into Pandas data.
+        Decode a base64 ASCII string back into pandas data.
 
         :param obj_type: type: The expected type of the decoded object (not used)
         :param obj_full: tuple: A tuple containing the encoded data string and object type
@@ -71,7 +71,7 @@ class PandasData(Plugin):
         :param kwargs: dict: Additional keyword arguments (not used)
         :return: Tuple[bool, Union[pandas.DataFrame, pandas.Series]]: A tuple containing:
             - bool: Always True, indicating that the decoding was successful
-            - Union[pandas.DataFrame, pandas.Series]: The decoded Pandas data
+            - Union[pandas.DataFrame, pandas.Series]: The decoded pandas data
         """
         with io.BytesIO(base64.b64decode(obj_full[1].encode('ascii'))) as memfile:
             obj = pandas.read_json(memfile, orient="split")


### PR DESCRIPTION
Following the naming specifications found in https://pandas.pydata.org/about/citing.html specifying that the pandas project name should be used in lower case, even at the beginning of a sentence.